### PR TITLE
Show hidden score message to learners if hide scores setting is enabled

### DIFF
--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -38,6 +38,8 @@
                 <b>{% trans "Annotated file from instructor" %}</b>
                 <a href="<%= annotatedUrl %>"><%= annotated.filename %></a>
               <% } %>
+            <% } else { %>
+              {% trans "Scores and remarks are hidden." %}
             <% } %>
           <% } else if (uploaded) { %>
             {% trans "Please review if you have uploaded the correct file. You can change the file by uploading another file above." %}<br/>


### PR DESCRIPTION
We can not hide scores from section visibility settings but there is SGA setting that we can use to achieve required behavior as shown in attached SS. This SGA setting is already there but was not working correctly so I did some code changes to fix it.

![image](https://user-images.githubusercontent.com/42185078/209795191-f5869c43-b34c-4cca-af32-7fe6e93c2aec.png)
